### PR TITLE
Replace "&nbsp;" with " "

### DIFF
--- a/AutoDefineAddon/autodefine.py
+++ b/AutoDefineAddon/autodefine.py
@@ -431,7 +431,7 @@ def insert_into_field(editor, text, field_id, overwrite=False):
 
 # via https://stackoverflow.com/a/12982689
 def clean_html(raw_html):
-    return re.sub(re.compile('<.*?>'), '', raw_html)
+    return re.sub(re.compile('<.*?>'), '', raw_html).replace("&nbsp;", " ")
 
 
 def setup_buttons(buttons, editor):


### PR DESCRIPTION
When there are spaces after the word, the .strip() doesn't remove those spaces because
they are "&nbsb;" not regular " ".